### PR TITLE
Initialize client component structure; add tests

### DIFF
--- a/client/src/__tests__/Main.test.js
+++ b/client/src/__tests__/Main.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import Main from '../components/Main.jsx';
+import { shallow, mount } from 'enzyme';
+
+it('redirects from root to id 1', () => {
+  const wrapper = mount(<Main />);
+  const id = <div>your id is 1</div>;
+  expect(wrapper.contains(id)).toEqual(true);
+});

--- a/client/src/__tests__/Order.test.js
+++ b/client/src/__tests__/Order.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Order from '../components/Order.jsx';
+import { shallow, mount, render } from 'enzyme';
+
+describe('Order component', () => {
+  it('renders a full summary for a bundle ID from 1 - 100', () => {
+    const wrapper = mount(<Order match={ {'params' : { 'id': 12 } } } />);
+    const id = <div>your id is 12</div>;
+    expect(wrapper.contains(id)).toEqual(true);
+  });
+
+  it('renders a check your ID for a bundle ID other than from 1 - 100', () => {
+    const wrapper = mount(<Order match={ {'params' : { 'id': 'grok' } } } />);
+    const id = <div>try an ID in the url from 1 - 100</div>
+    expect(wrapper.contains(id)).toEqual(true);
+  });
+})
+

--- a/client/src/components/Main.jsx
+++ b/client/src/components/Main.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route, Redirect, BrowserRouter as Router } from 'react-router-dom';
 import Order from './Order.jsx';
 
 const Main = (props) => {
   return (
     <section>
-      <Switch>
-        <Redirect exact from='/' to='/1' />
-        <Route path='/:id' component={Order} />
-      </Switch>
+      <Router>
+        <Switch>
+          <Redirect exact from='/' to='/1' />
+          <Route path='/:id' component={Order} />
+        </Switch>
+      </Router>
     </section>
   );
 };

--- a/client/src/components/Main.jsx
+++ b/client/src/components/Main.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Switch, Route, Redirect } from 'react-router-dom';
+import Order from './Order.jsx';
+
+const Main = (props) => {
+  return (
+    <section>
+      <Switch>
+        <Redirect exact from='/' to='/1' />
+        <Route path='/:id' component={Order} />
+      </Switch>
+    </section>
+  );
+};
+
+export default Main;

--- a/client/src/components/Order.jsx
+++ b/client/src/components/Order.jsx
@@ -1,0 +1,13 @@
+import React, { useState, useEffect } from 'react';
+
+const Order = (props) => {
+  const [id, setId] = useState(props.match.params.id);
+
+  return (
+    <div>
+      <div>your id is {id}</div>
+    </div>
+  );
+};
+
+export default Order;

--- a/client/src/components/Order.jsx
+++ b/client/src/components/Order.jsx
@@ -3,9 +3,17 @@ import React, { useState, useEffect } from 'react';
 const Order = (props) => {
   const [id, setId] = useState(props.match.params.id);
 
+  if (parseInt(id) >= 1 && parseInt(id) <= 100) {
+    return (
+      <div>
+        <div>your id is {id}</div>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <div>your id is {id}</div>
+      <div>try an ID in the url from 1 - 100</div>
     </div>
   );
 };

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
+// import { BrowserRouter as Router } from 'react-router-dom';
 import Main from './components/Main.jsx';
 
 render((
-  <Router>
-    <Main />
-  </Router>
+  <Main />
 ), document.getElementById('purchase'));

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,1 +1,10 @@
-import React, { useState, useEffect } from 'React';
+import React from 'react';
+import { render } from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+import Main from './components/Main.jsx';
+
+render((
+  <Router>
+    <Main />
+  </Router>
+), document.getElementById('purchase'));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "to describe the purchase module",
   "main": "index.js",
   "scripts": {
-    "test": "jest --forceExit",
+    "test": "jest",
     "plough": "mysql -u root < schema.sql",
     "server-dev": "nodemon server/index.js",
     "seed": "npm run plough && node utils/seed.js",

--- a/server/index.js
+++ b/server/index.js
@@ -7,11 +7,11 @@ db.sync({
   force: false,
   logging: false
 })
-  .then(() => {
-    app.listen(port, () => {
-      console.log(`dockside at port ${port}`);
-    })
+.then(() => {
+  app.listen(port, () => {
+    console.log(`dockside at port ${port}`);
   })
-  .catch((err) => {
-    console.log('your error: ', err);
-  });
+})
+.catch((err) => {
+  console.log('your error: ', err);
+});


### PR DESCRIPTION
**client/src/__tests__/Main.test.js**; **client/src/__tests__/Order.test.js**
I've added a few tests for the Main & Order components. Since the Main's only real function is as the entry point for the router, I'm just testing whether the redirect works. For the Order component, I'm testing that if the input id from the url is between 1-100, then it's rendering a simple phrase referencing the id.

**client/src/components/Main.jsx**; **client/src/components/Order.jsx**; **client/src/index.jsx**
I've added a simple client component through the file chain of index.jsx -> components/Main.jsx -> components/Order.jsx. Starting in index, we render the component defined in Main, which sets up routing that displays an Order.

Everything else was a minor adjustment, taking a `forceExit` flag off the testing script and removing some unnecessary whitespace in the server files.